### PR TITLE
Fix UI break

### DIFF
--- a/packages/iron-realms-nexus-typings/definitions/Nexus3/index.d.ts
+++ b/packages/iron-realms-nexus-typings/definitions/Nexus3/index.d.ts
@@ -59,4 +59,19 @@ declare namespace nexusclient {
   export interface EncodedReflex {
     [key: string]: unknown
   }
+
+  export interface Interface {
+    layout(): LayoutManager
+  }
+
+  export interface LayoutManager{
+    register_custom_tab(name: string, component?: string | React.JSX.Element): void
+    custom_tabs(): {[key:string]: unkown}
+    unregister_custom_tab(name: string): void
+  }
+
+  export interface NexusPlatform{
+    real_mobile(): boolean
+    is_desktop(): boolean
+  }
 }

--- a/packages/iron-realms-nexus-typings/definitions/client-api.d.ts
+++ b/packages/iron-realms-nexus-typings/definitions/client-api.d.ts
@@ -48,4 +48,7 @@ declare namespace nexusclient {
   export function packages(): ReflexPackages
   export function reflexes(): Reflexes
   export function send_commands(input: string, no_expansion = false): boolean?
+  export function display_notice(...params: string[]): void
+  export function ui(): Interface
+  export function platform(): NexusPlatform
 }

--- a/packages/nexus-package-manager/webpack/webpack.tsx
+++ b/packages/nexus-package-manager/webpack/webpack.tsx
@@ -7,11 +7,9 @@ const packageManager = new PackageManager();
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 globalThis.packageManager = packageManager;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-if (globalThis.React && nexusclient.ui().layout().register_custom_tab && !nexusclient.platform().real_mobile() && !nexusclient.platform().is_desktop() ) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+
+if (globalThis.React && !nexusclient.platform().real_mobile() && !nexusclient.platform().is_desktop() ) {
+
   const layout = nexusclient.ui().layout();
   const tabName = 'npkg_ui';
   if(layout.custom_tabs()[tabName]){
@@ -19,8 +17,6 @@ if (globalThis.React && nexusclient.ui().layout().register_custom_tab && !nexusc
   }
   layout.register_custom_tab(tabName, <PackageManagerUi packageManager={packageManager} />);
 }else{
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   nexusclient.display_notice('This platform is not supported by the package manager.')
 }
 

--- a/packages/nexus-package-manager/webpack/webpack.tsx
+++ b/packages/nexus-package-manager/webpack/webpack.tsx
@@ -12,7 +12,12 @@ globalThis.packageManager = packageManager;
 if (globalThis.React && nexusclient.ui().layout().register_custom_tab && !nexusclient.platform().real_mobile() && !nexusclient.platform().is_desktop() ) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  nexusclient.ui().layout().register_custom_tab('npk_ui', <PackageManagerUi packageManager={packageManager} />);
+  const layout = nexusclient.ui().layout();
+  const tabName = 'npkg_ui';
+  if(layout.custom_tabs()[tabName]){
+    layout.unregister_custom_tab(tabName)
+  }
+  layout.register_custom_tab(tabName, <PackageManagerUi packageManager={packageManager} />);
 }else{
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore


### PR DESCRIPTION
Changes on IRE side lead to the package manager UI crashing the UI on load. We now apply a workaround to make sure this doesn't happen anymore.

I also took the chance to add more typings so we can get rid of more TS and eslint magic comments.